### PR TITLE
Add support for nested variables in routes.

### DIFF
--- a/router.go
+++ b/router.go
@@ -108,13 +108,15 @@ func (r *Router) NewMatcher() *Matcher {
 // Add creates a new Route and registers the instance within the Router
 func (r *Router) Add(method string, path string) *Route {
 	route := NewRoute(method, path)
-	return r.Use(route)
+	return r.Use(route)[0]
 }
 
-// Use registers a Route instance within the Router
-func (r *Router) Use(route *Route) *Route {
-	r.routes.AddRouteToTree(route, r.variables)
-	return route
+// Use registers one or more Route instances within the Router
+func (r *Router) Use(routes ...*Route) []*Route {
+	for _, route := range routes {
+		r.routes.AddRouteToTree(route, r.variables)
+	}
+	return routes
 }
 
 // AddStatic registers a directory to serve static files

--- a/router_test.go
+++ b/router_test.go
@@ -92,6 +92,11 @@ func TestMain(t *testing.T) {
 
 	testHandle := chain.ThenFunc(testHandler)
 
+	router.SetStringVariable("a", "alpha$b$c")
+	router.SetStringVariable("b", "bar")
+	router.SetStringVariable("c", "$d")
+	router.SetStringVariable("d", "baz")
+
 	router.Add("GET", "/").
 		Handle(testHandle)
 	router.Add("GET", "/users/:id/*").
@@ -105,6 +110,8 @@ func TestMain(t *testing.T) {
 	router.Add("GET", "/users/:id/show/:what").
 		Handle(testHandle)
 	router.Add("GET", "/*").
+		Handle(testHandle)
+	router.Add("GET", "/$a$b").
 		Handle(testHandle)
 
 	reqMocks := []RequestMock{


### PR DESCRIPTION
Assuming that the following are defined....
```
	router.SetStringVariable("a", "alpha$b$c")
	router.SetStringVariable("b", "bar")
	router.SetStringVariable("c", "$d")
	router.SetStringVariable("d", "baz")
```

The following routes should be identical after being resolved.
`"/users/:id/show/$a/:what"` 
`"/users/:id/show/alpha$b$c/:what"` 
`"/users/:id/show/alphabarbaz/:what"`.

